### PR TITLE
add pull request template for IN6000 repositories

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+
+
+<!-- Required for IN6000 repositories:
+     ---------------------------------
+     Link related issues here. Do not uncomment these blocks or mention the issues in visible areas to avoid issue linking noise.
+     Mention one or multiple issues comma separated in the form: #101, #102 -->
+<!-- Linked Issues: #000 -->


### PR DESCRIPTION
It seems the first approach didnt work to make the PR template visible.

With this PR another template file is added to the repo that should be taken as default for pull requests.